### PR TITLE
chore: CI only test on maintained Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3]
+        ruby: [3.2, 3.3, 3.4]
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
### What
- Test CI against currently maintained Ruby versions only.