### PR TITLE
chore: release gem via trusted publishing from RubyGems

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
- name: Run release-please
+ name: Run release-please and publish gem
  on:
    push:
      branches:
@@ -6,33 +6,29 @@
  jobs:
    release-please:
      runs-on: ubuntu-latest
+     permissions:
+       contents: write
+       id-token: write
+     # If you configured a GitHub environment on RubyGems, you must use it here.
+     environment: release
      steps:
        - uses: GoogleCloudPlatform/release-please-action@v4
          id: release
          with:
            token: ${{ secrets.GITHUB_TOKEN }}
-       # Checkout code if release was created
+
+       # Set up
        - uses: actions/checkout@v5
-         if: ${{ steps.release.outputs.release_created }}
-       # Setup ruby if a release was created
-       - uses: ruby/setup-ruby@v1
          with:
+           persist-credentials: false
+         if: ${{ steps.release.outputs.release_created }}
+       - name: Set up Ruby
+         uses: ruby/setup-ruby@v1
+         with:
+           bundler-cache: true
            ruby-version: ${{ vars.RUBY_VERSION }}
          if: ${{ steps.release.outputs.release_created }}
-       # Bundle install
-       - run: bundle install
-         if: ${{ steps.release.outputs.release_created }}
-       # Publish
-       - name: publish gem
-         run: |
-           mkdir -p $HOME/.gem
-           touch $HOME/.gem/credentials
-           chmod 0600 $HOME/.gem/credentials
-           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-           gem build *.gemspec
-           gem push *.gem
-         env:
-           # Make sure to update the secret name
-           # if yours isn't named RUBYGEMS_AUTH_TOKEN
-           GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+
+       # Release
+       - uses: rubygems/release-gem@v1
          if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
### What
- Use recommended way to publish gem from [RubyGems](https://guides.rubygems.org/trusted-publishing/releasing-gems/) via [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/adding-a-publisher/)
